### PR TITLE
Remove wildcard imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-from view import *
-from model import *
+from view import App
+from model import Model
 
 app = App()
 app.model = Model()

--- a/view.py
+++ b/view.py
@@ -109,21 +109,24 @@ class App(tk.Frame):
 
         serialmenu = tk.Menu(menubar, tearoff=0)
         serialmenu.add_command(label="Connect", command=self.command_connect)
-        serialmenu.add_command(label="Disconnect", command=self.command_disconnect)
+        serialmenu.add_command(label="Disconnect",
+                               command=self.command_disconnect)
         serialmenu.add_command(label="Show log", command=self.command_save)
         menubar.add_cascade(label="Serial", menu=serialmenu)
         return menubar
 
     def command_open(self):
-        filename = filedialog.askopenfilename(title="Open file", filetypes=self.fileType)
-        if (filename):
+        filename = filedialog.askopenfilename(title="Open file",
+                                              filetypes=self.fileType)
+        if filename:
             file = open(filename, 'r')
             self.set_title(filename)
             self.model.data = file.read()
 
     def command_save(self):
-        filename = filedialog.asksaveasfilename(title="Save file", filetypes=self.fileType)
-        if (filename):
+        filename = filedialog.asksaveasfilename(title="Save file",
+                                                filetypes=self.fileType)
+        if filename:
             with open(filename, 'w') as file:
                 file.write(self.model.originalData)
             self.set_title(filename + ' Saved')

--- a/view.py
+++ b/view.py
@@ -1,12 +1,12 @@
-from tkinter import *
-from tkinter import filedialog, Frame
+import tkinter as tk
+from tkinter import filedialog
 
 from matplotlib.backends.backend_tkagg import (FigureCanvasTkAgg)
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 
 
-class App(Frame):
+class App(tk.Frame):
     title = "Rev counter"
     size = "700x500"
     fileType = (("csv", "*.csv"), ("all files", "*.*"))
@@ -32,8 +32,8 @@ class App(Frame):
         self.win.title(self.title + ' ' + title)
 
     def __init__(self,  *args, **kwargs):
-        win = Tk()
-        Frame.__init__(self, win, *args, **kwargs)
+        win = tk.Tk()
+        tk.Frame.__init__(self, win, *args, **kwargs)
 
         self.win = win
         win.geometry(self.size)
@@ -53,7 +53,7 @@ class App(Frame):
         axis.set_ylabel("Revs [rev/min]")
 
         canvas = FigureCanvasTkAgg(figure, master=self.win)
-        canvas.get_tk_widget().pack(side=TOP, fill=BOTH, expand=1)
+        canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=1)
         canvas.draw()
         self.axis = axis
         self.canvas = canvas
@@ -98,16 +98,16 @@ class App(Frame):
 
 
     def generate_menu_bar(self, win):
-        menubar = Menu(win)
+        menubar = tk.Menu(win)
 
-        filemenu = Menu(menubar, tearoff=0)
+        filemenu = tk.Menu(menubar, tearoff=0)
         filemenu.add_command(label="Open", command=self.command_open)
         filemenu.add_command(label="Save", command=self.command_save)
         filemenu.add_separator()
         filemenu.add_command(label="Exit", command=self.command_quit)
         menubar.add_cascade(label="File", menu=filemenu)
 
-        serialmenu = Menu(menubar, tearoff=0)
+        serialmenu = tk.Menu(menubar, tearoff=0)
         serialmenu.add_command(label="Connect", command=self.command_connect)
         serialmenu.add_command(label="Disconnect", command=self.command_disconnect)
         serialmenu.add_command(label="Show log", command=self.command_save)

--- a/view.py
+++ b/view.py
@@ -60,7 +60,7 @@ class App(tk.Frame):
 
     def draw_data(self, data):
         axis = self.axis
-        range = {
+        ranges = {
             'xmin': 0,
             'xmax': 0,
             'ymin': 0,
@@ -77,19 +77,19 @@ class App(tk.Frame):
             y = data[sensor]['y']
             line.set_data(x, y)
             try:
-                range['xmin'] = min(min(x), range['xmin'])
-                range['ymin'] = min(min(y), range['ymin'])
-                range['xmax'] = max(max(x), range['xmax'])
-                range['ymax'] = max(max(y), range['ymax'])
+                ranges['xmin'] = min(min(x), ranges['xmin'])
+                ranges['ymin'] = min(min(y), ranges['ymin'])
+                ranges['xmax'] = max(max(x), ranges['xmax'])
+                ranges['ymax'] = max(max(y), ranges['ymax'])
             except:
-                range['xmin'] = 0
-                range['ymin'] = 0
-                range['xmax'] = 0
-                range['ymax'] = 0
+                ranges['xmin'] = 0
+                ranges['ymin'] = 0
+                ranges['xmax'] = 0
+                ranges['ymax'] = 0
         axis.legend()
 
-        axis.set_xlim(range['xmin'], range['xmax'])
-        axis.set_ylim(range['ymin'], range['ymax'])
+        axis.set_xlim(ranges['xmin'], ranges['xmax'])
+        axis.set_ylim(ranges['ymin'], ranges['ymax'])
 
         try:
             self.canvas.draw()


### PR DESCRIPTION
I removed wildcard imports since they are discouraged by PEP8 [1] although `from tkinter import *` is suggested by its docs page [2].
Also I did a few minor style changes.
And fixed redefining of the `range` built-in. This might IMHO lead to quite annoying state of the code if gone wild :-]

[1] https://www.python.org/dev/peps/pep-0008/#id23
[2] https://docs.python.org/3/library/tkinter.html